### PR TITLE
use conda-forge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,12 @@ before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
   - conda update conda
-  - conda config --add channels odm2 --force
-  - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
+  - conda config --add channels conda-forge --force
+  - conda create --name TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
   - source activate TEST
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      conda install --yes mock ;
+      conda install  mock ;
     fi
-  # Coding standards.
-  - conda install --channel conda-forge --yes flake8-print flake8-quotes flake8-import-order flake8-builtins flake8-comprehensions flake8-mutable
 
 # FIXME: Test source distribution.
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
     - cmd: conda update conda
-    - cmd: conda config --add channels odm2 --force
+    - cmd: conda config --add channels conda-forge --force
     - cmd: conda create -n TEST python=2.7 mock --file requirements.txt --file requirements-dev.txt
     - cmd: activate TEST
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,10 @@ pytest
 pytest-cov
 pyyaml
 sqlalchemy
+# coding standards
+flake8-print
+flake8-quotes
+flake8-import-order
+flake8-builtins
+flake8-comprehensions
+flake8-mutable


### PR DESCRIPTION
@lsetiawan and @emiliom this PR makes use of the conda-forge version of the `odm2` packages. If things are working as expected we can re-add the `flak8-*` in the `requirements-dev.txt ` b/c, without a 3rd channel, we reduce the channel incompatibilities.

Note that the tests are failing in master and the same failures will happen here but they are unrelated to this PR.